### PR TITLE
test: add rpc() method coverage across all runners

### DIFF
--- a/test/runners.test.ts
+++ b/test/runners.test.ts
@@ -501,6 +501,18 @@ for (const { name, create, skip } of rpcRunners) {
       // "slow" handler responds after 2s, so a 100ms timeout should fire first
       await expect(runner.rpc("slow", undefined, { timeout: 100 })).rejects.toThrow("timed out");
     });
+
+    it("handles concurrent rpc calls", async () => {
+      runner = create({ name: "test-rpc-concurrent", data: { entry: appRpcEntry } });
+      await runner.waitForReady();
+
+      const results = await Promise.all([
+        runner.rpc<string>("greet", "a"),
+        runner.rpc<string>("greet", "b"),
+        runner.rpc<string>("greet", "c"),
+      ]);
+      expect(results).toEqual(["hello a", "hello b", "hello c"]);
+    });
   });
 }
 

--- a/test/runners.test.ts
+++ b/test/runners.test.ts
@@ -443,6 +443,67 @@ for (const { name, create, selfRunner } of upgradeRunners) {
   });
 }
 
+// --- RPC tests ---
+
+const appRpcEntry = resolve(_dir, "./fixtures/app-rpc.mjs");
+
+const rpcRunners = [
+  { name: "NodeWorkerEnvRunner", create: (opts: any) => new NodeWorkerEnvRunner(opts) },
+  { name: "NodeProcessEnvRunner", create: (opts: any) => new NodeProcessEnvRunner(opts) },
+  {
+    name: "BunProcessEnvRunner",
+    create: (opts: any) => new BunProcessEnvRunner(opts),
+    skip: !hasBun,
+  },
+  {
+    name: "DenoProcessEnvRunner",
+    create: (opts: any) => new DenoProcessEnvRunner(opts),
+    skip: !hasDeno,
+  },
+  {
+    name: "SelfEnvRunner",
+    create: (opts: any) => new SelfEnvRunner(opts),
+  },
+  {
+    name: "MiniflareEnvRunner",
+    create: (opts: any) => new MiniflareEnvRunner(opts),
+  },
+];
+
+for (const { name, create, skip } of rpcRunners) {
+  describe.skipIf(skip ?? false)(`${name} rpc`, () => {
+    let runner: EnvRunner | undefined;
+
+    afterEach(async () => {
+      await runner?.close();
+      runner = undefined;
+    });
+
+    it("resolves with response data", async () => {
+      runner = create({ name: "test-rpc", data: { entry: appRpcEntry } });
+      await runner.waitForReady();
+
+      const result = await runner.rpc<string>("greet", "world");
+      expect(result).toBe("hello world");
+    });
+
+    it("rejects when worker returns an error", async () => {
+      runner = create({ name: "test-rpc-error", data: { entry: appRpcEntry } });
+      await runner.waitForReady();
+
+      await expect(runner.rpc("fail")).rejects.toThrow("something went wrong");
+    });
+
+    it("rejects on timeout", async () => {
+      runner = create({ name: "test-rpc-timeout", data: { entry: appRpcEntry } });
+      await runner.waitForReady();
+
+      // "slow" handler responds after 2s, so a 100ms timeout should fire first
+      await expect(runner.rpc("slow", undefined, { timeout: 100 })).rejects.toThrow("timed out");
+    });
+  });
+}
+
 // --- Helpers ---
 
 function waitForReady(runner: EnvRunner, timeout = 5000): Promise<void> {


### PR DESCRIPTION
## Summary

- The `rpc()` method had zero test coverage despite `test/fixtures/app-rpc.mjs` existing with three handlers (`greet`, `fail`, `slow`)
- Adds 4 parameterized tests running across all 6 runners (NodeWorker, NodeProcess, BunProcess, DenoProcess, Self, Miniflare):
  - Success path (greet handler returns data)
  - Error propagation (fail handler throws, caller rejects)
  - Timeout rejection (slow handler with 100ms timeout)
  - Concurrent calls (3 parallel RPCs resolve independently)

Follows the existing parameterized pattern in `test/runners.test.ts`. Runners requiring specific runtimes (bun, deno) are auto-skipped when unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for RPC functionality across multiple runtime environments, covering success responses, error handling, timeout behavior, and concurrent call scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->