### PR TITLE
fix(node-process, bun-process): exit worker on IPC disconnect to avoid orphans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,9 +303,12 @@ const runner2 = new NodeProcessEnvRunner({
 - Test fixture in `test/fixtures/app-websocket.mjs` — Entry with crossws WebSocket hooks for websocket tests
 - Test fixture in `test/fixtures/app-headers.mjs` — Entry that echoes all request headers as JSON for vercel header injection tests
 - Test fixture in `test/fixtures/app-env.mjs` — Entry that echoes request headers and selected environment variables as JSON
+- Test fixture in `test/fixtures/app-pid.mjs` — Entry that responds with the worker `process.pid` for orphan tests
+- Test fixture in `test/fixtures/orphan-supervisor.mjs` — Standalone supervisor process that spawns a runner, prints worker pid/address, and stays alive until SIGKILLed (for orphan tests)
+- **`test/orphan.test.ts`** — Regression tests for orphaned workers (#23): SIGKILLs the supervisor process and asserts the worker stops serving HTTP (node-process, bun-process under both Node and Bun hosts)
 - **`test/vercel.test.ts`** — Tests for `VercelEnvRunner`: request header injection (`x-vercel-deployment-url`, `x-vercel-id`, `x-vercel-forwarded-for`, `x-forwarded-for`, `x-real-ip`, `x-forwarded-proto`, `x-forwarded-host`), response header injection (`server`, `x-vercel-id`, `x-vercel-cache`), environment variables (`VERCEL`, `VERCEL_ENV`, `VERCEL_REGION`, `NOW_REGION`), header preservation, pre-existing header respect
 - **`test/netlify.test.ts`** — Tests for `NetlifyEnvRunner`: header injection (`x-nf-client-connection-ip`, `x-nf-account-id`, `x-nf-site-id`, `x-nf-deploy-id`, `x-nf-deploy-context`, `x-nf-geo`, `x-nf-request-id`), IP derivation, header preservation
-- Tests cover: lifecycle, fetch (GET/POST), WebSocket upgrade, crossws websocket, messaging, hooks, graceful close, inspect output, manager hot-reload, message queueing, miniflare hot-reload, vercel header/env/response injection, netlify header injection, waitForReady, vite helpers
+- Tests cover: lifecycle, fetch (GET/POST), WebSocket upgrade, crossws websocket, messaging, hooks, graceful close, inspect output, manager hot-reload, message queueing, miniflare hot-reload, vercel header/env/response injection, netlify header injection, waitForReady, vite helpers, orphan-worker exit on supervisor death
 
 ## Scripts
 

--- a/src/runners/bun-process/worker.ts
+++ b/src/runners/bun-process/worker.ts
@@ -32,6 +32,10 @@ process.send!({
   address: parseServerAddress(server),
 });
 
+// Exit when the supervisor disappears (graceful or crash) to avoid orphan workers.
+// Relies on Bun's Node-compat layer when the host is Bun; verified empirically.
+process.on("disconnect", () => process.exit(0));
+
 process.on("message", async (message: any) => {
   if (message?.event === "shutdown") {
     Promise.resolve(entry.ipc?.onClose?.())

--- a/src/runners/node-process/worker.ts
+++ b/src/runners/node-process/worker.ts
@@ -32,6 +32,9 @@ process.send!({
   address: parseServerAddress(server),
 });
 
+// Exit when the supervisor disappears (graceful or crash) to avoid orphan workers.
+process.on("disconnect", () => process.exit(0));
+
 process.on("message", async (message: any) => {
   if (message?.event === "shutdown") {
     Promise.resolve(entry.ipc?.onClose?.())

--- a/test/fixtures/app-pid.mjs
+++ b/test/fixtures/app-pid.mjs
@@ -1,0 +1,5 @@
+export default {
+  fetch() {
+    return new Response(String(process.pid));
+  },
+};

--- a/test/fixtures/orphan-supervisor.mjs
+++ b/test/fixtures/orphan-supervisor.mjs
@@ -1,0 +1,37 @@
+// Supervisor process for orphan-worker regression tests (test/orphan.test.ts).
+// Spawns a runner, prints the worker pid + address as JSON, then stays alive until killed.
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+
+const _dir = dirname(fileURLToPath(import.meta.url));
+const entry = resolve(_dir, "app-pid.mjs");
+
+const runnerName = process.argv[2];
+const { NodeProcessEnvRunner } = await import("../../src/runners/node-process/runner.ts");
+const { BunProcessEnvRunner } = await import("../../src/runners/bun-process/runner.ts");
+
+let address;
+const opts = {
+  name: "orphan-test",
+  data: { entry },
+  hooks: {
+    onReady: (_runner, addr) => {
+      address = addr;
+    },
+  },
+};
+
+const runners = {
+  "node-process": () => new NodeProcessEnvRunner(opts),
+  "bun-process": () => new BunProcessEnvRunner(opts),
+};
+
+const runner = runners[runnerName]();
+await runner.waitForReady();
+
+const res = await runner.fetch("http://localhost/");
+const workerPid = Number(await res.text());
+console.log(JSON.stringify({ workerPid, address }));
+
+// Keep the supervisor alive until killed externally (SIGKILL from the test)
+setInterval(() => {}, 1000);

--- a/test/orphan.test.ts
+++ b/test/orphan.test.ts
@@ -1,0 +1,105 @@
+import { spawn, execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Regression tests for https://github.com/unjs/env-runner/issues/23:
+// workers must exit when the supervisor dies non-gracefully (SIGKILL) instead
+// of being reparented to PID 1 and continuing to serve requests.
+
+function hasRuntime(cmd: string): boolean {
+  try {
+    execFileSync(cmd, ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const hasBun = hasRuntime("bun");
+
+const _dir = dirname(fileURLToPath(import.meta.url));
+const supervisorEntry = resolve(_dir, "./fixtures/orphan-supervisor.mjs");
+
+// The worker keeps serving HTTP while alive, so probe its port instead of the
+// pid: a killed-but-unreaped worker is a zombie that still passes kill(pid, 0).
+async function fetchWorker(address: { host?: string; port: number }): Promise<string | undefined> {
+  try {
+    const res = await fetch(`http://${address.host || "127.0.0.1"}:${address.port}/`, {
+      signal: AbortSignal.timeout(1000),
+    });
+    return await res.text();
+  } catch {
+    return undefined; // connection refused — worker is gone
+  }
+}
+
+const cases: { name: string; runner: string; skip?: boolean; bunHost?: boolean }[] = [
+  { name: "NodeProcessEnvRunner", runner: "node-process" },
+  { name: "BunProcessEnvRunner (node host)", runner: "bun-process", skip: !hasBun },
+  { name: "BunProcessEnvRunner (bun host)", runner: "bun-process", bunHost: true, skip: !hasBun },
+];
+
+describe("orphan workers on supervisor death", () => {
+  for (const c of cases) {
+    const exec = c.bunHost ? "bun" : process.execPath;
+    it.skipIf(c.skip ?? false)(
+      `${c.name}: worker exits when supervisor is SIGKILLed`,
+      { timeout: 20_000 },
+      async () => {
+        const supervisor = spawn(exec, [supervisorEntry, c.runner], {
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+
+        let workerPid: number | undefined;
+        try {
+          // Wait for the supervisor to report the worker pid + address
+          let stderr = "";
+          supervisor.stderr!.on("data", (chunk) => (stderr += chunk));
+          const info = await new Promise<{
+            workerPid: number;
+            address: { host?: string; port: number };
+          }>((resolve, reject) => {
+            let buf = "";
+            supervisor.stdout!.on("data", (chunk) => {
+              buf += chunk;
+              const line = buf.split("\n").find((l) => l.startsWith("{"));
+              if (line) resolve(JSON.parse(line));
+            });
+            supervisor.once("exit", (code) =>
+              reject(new Error(`supervisor exited early (code ${code}): ${stderr}`)),
+            );
+            setTimeout(
+              () => reject(new Error(`timeout waiting for supervisor: ${stderr}`)),
+              10_000,
+            );
+          });
+          workerPid = info.workerPid;
+
+          // Sanity check: worker is serving before the supervisor dies
+          expect(await fetchWorker(info.address)).toBe(String(workerPid));
+
+          // Simulate non-graceful supervisor death (no IPC shutdown message)
+          supervisor.kill("SIGKILL");
+
+          // The worker should exit shortly after the IPC channel closes
+          let alive: string | undefined;
+          const deadline = Date.now() + 5000;
+          do {
+            await new Promise((r) => setTimeout(r, 100));
+            alive = await fetchWorker(info.address);
+          } while (alive !== undefined && Date.now() < deadline);
+
+          expect(alive, `worker ${workerPid} kept serving after supervisor death`).toBeUndefined();
+        } finally {
+          supervisor.kill("SIGKILL");
+          if (workerPid) {
+            try {
+              process.kill(workerPid, "SIGKILL"); // clean up orphan if the test failed
+            } catch {}
+          }
+        }
+      },
+    );
+  }
+});


### PR DESCRIPTION
Closes #23.

When the supervisor dies non-gracefully (SIGKILL, uncaught exception that bypasses cleanup, terminal SIGHUP, etc.), the IPC channel closes but the worker keeps running — reparented to PID 1, still serving requests on its random port, still holding any resources its entry module opened (DB pools, file handles, etc.).

Add a one-line `process.on("disconnect", () => process.exit(0))` to both IPC-based workers. The graceful shutdown path is unaffected: the supervisor sends `{ event: "shutdown" }` over still-open IPC, the worker drains and replies `{ event: "exit" }`, and only then does `_closeRuntime()` kill the child. `disconnect` fires only when the channel closes *without* a prior shutdown message — exactly the orphan case.

### Scope

- `src/runners/node-process/worker.ts` — Node IPC, well-defined `disconnect` semantics.
- `src/runners/bun-process/worker.ts` — works for both Node host (Node IPC) and Bun host (`Bun.spawn({ ipc })`). Verified empirically in Bun 1.3.11; relies on Bun's Node-compat layer for `process.on("disconnect")`.

Other runners (`deno-process`, `vercel`, `netlify`, `miniflare`) are out of scope. `deno-process` has the same orphan class but uses stdin/stdout JSON-lines, so its fix is to exit on stdin EOF rather than `disconnect`. Happy to file that as a follow-up.

### Test plan

- [x] Manual reproduction: spawn worker, kill supervisor with `SIGKILL`; verified the worker exits within ms instead of being reparented to PID 1. Same result with Node parent → Bun child and Bun parent → Bun child.
- [ ] Could add an automated test that spawns a runner, kills the supervisor process, and asserts the child is gone. Let me know if you want that in this PR or a follow-up.

### Risks

The change is a no-op on the graceful path (IPC stays open until after `event: "exit"` is sent). The only behavioral change is in the orphan-leak case. Bun's `process.on("disconnect")` compat behavior is empirically correct in current Bun but isn't pinned by any spec — if Bun ever changes it, the bun-process fix would silently regress to current behavior (orphan). The node-process fix has no such caveat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker process lifecycle management to ensure proper cleanup when the parent process disconnects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/env-runner/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->