### PR TITLE
fix: forward child stdio for process runners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,7 +305,7 @@ const runner2 = new NodeProcessEnvRunner({
 - Test fixture in `test/fixtures/app-env.mjs` — Entry that echoes request headers and selected environment variables as JSON
 - **`test/vercel.test.ts`** — Tests for `VercelEnvRunner`: request header injection (`x-vercel-deployment-url`, `x-vercel-id`, `x-vercel-forwarded-for`, `x-forwarded-for`, `x-real-ip`, `x-forwarded-proto`, `x-forwarded-host`), response header injection (`server`, `x-vercel-id`, `x-vercel-cache`), environment variables (`VERCEL`, `VERCEL_ENV`, `VERCEL_REGION`, `NOW_REGION`), header preservation, pre-existing header respect
 - **`test/netlify.test.ts`** — Tests for `NetlifyEnvRunner`: header injection (`x-nf-client-connection-ip`, `x-nf-account-id`, `x-nf-site-id`, `x-nf-deploy-id`, `x-nf-deploy-context`, `x-nf-geo`, `x-nf-request-id`), IP derivation, header preservation
-- Tests cover: lifecycle, fetch (GET/POST), WebSocket upgrade, crossws websocket, messaging, hooks, graceful close, inspect output, manager hot-reload, message queueing, miniflare hot-reload, vercel header/env/response injection, netlify header injection, waitForReady, vite helpers
+- Tests cover: lifecycle, fetch (GET/POST), WebSocket upgrade, crossws websocket, messaging, hooks, graceful close, inspect output, stdio forwarding (all runners), manager hot-reload, message queueing, miniflare hot-reload, vercel header/env/response injection, netlify header injection, waitForReady, vite helpers
 
 ## Scripts
 
@@ -334,6 +334,7 @@ const runner2 = new NodeProcessEnvRunner({
 - **Message-driven readiness** — Workers/processes post `{ address }` to signal ready state
 - **Immediate shutdown** — `close()` immediately terminates the worker/process (no graceful shutdown handshake)
 - **Data passing:** Worker threads use `workerData`, processes use `ENV_RUNNER_DATA` env var (JSON), self runner uses in-memory channel, miniflare runner uses in-memory `script` with `unsafeModuleFallbackService` for module resolution
+- **Stdio forwarding** — All runners forward entry stdout/stderr to the host process: node-process and bun-process pipe child streams to `process.stdout`/`process.stderr`, deno-process forwards non-IPC stdout lines (stdout doubles as NDJSON IPC) and pipes stderr, worker threads use Node.js's built-in forwarding, miniflare uses its default runtime stdio handler
 - **Socket cleanup** — `_closeSocket()` avoids deleting Windows named pipes and abstract sockets
 - **Custom inspect** — `[Symbol.for('nodejs.util.inspect.custom')]()` shows pending/ready/closed status
 - **Adding a new runner** — Create `src/runners/<name>/runner.ts` extending `BaseEnvRunner`, optionally add `worker.ts`, add export path in `package.json`, add to `loaders` map in `src/loader.ts`, re-export from `src/index.ts`

--- a/src/runners/bun-process/runner.ts
+++ b/src/runners/bun-process/runner.ts
@@ -173,6 +173,9 @@ export class BunProcessEnvRunner extends BaseEnvRunner {
       this._handleMessage(message);
     });
 
+    child.stdout?.pipe(process.stdout);
+    child.stderr?.pipe(process.stderr);
+
     this.#process = handle;
   }
 

--- a/src/runners/bun-process/runner.ts
+++ b/src/runners/bun-process/runner.ts
@@ -26,6 +26,20 @@ interface ProcessHandle {
 // @ts-expect-error Bun global
 const _isBun = typeof Bun !== "undefined";
 
+async function forwardStream(
+  stream: AsyncIterable<Uint8Array> | undefined,
+  dest: NodeJS.WriteStream,
+) {
+  if (!stream) return;
+  try {
+    for await (const chunk of stream) {
+      dest.write(chunk);
+    }
+  } catch {
+    // Stream closed (process exited)
+  }
+}
+
 function resolveBunPath(): string {
   if (_bunPath) return _bunPath;
   // Check common locations
@@ -133,6 +147,9 @@ export class BunProcessEnvRunner extends BaseEnvRunner {
       child._exitCode = code;
       this.close(`process exited with code ${code}`);
     });
+
+    forwardStream(proc.stdout, process.stdout);
+    forwardStream(proc.stderr, process.stderr);
 
     this.#process = child;
   }

--- a/src/runners/deno-process/runner.ts
+++ b/src/runners/deno-process/runner.ts
@@ -115,7 +115,7 @@ export class DenoProcessEnvRunner extends BaseEnvRunner {
       }
     });
 
-    // Parse newline-delimited JSON from stdout for IPC
+    // Parse newline-delimited JSON from stdout for IPC, forward other output
     let buffer = "";
     child.stdout!.on("data", (chunk: Buffer) => {
       buffer += chunk.toString();
@@ -126,12 +126,16 @@ export class DenoProcessEnvRunner extends BaseEnvRunner {
         if (line.startsWith("{")) {
           try {
             this._handleMessage(JSON.parse(line));
+            continue;
           } catch {
-            // Not JSON, ignore
+            // Not JSON, forward as regular output
           }
         }
+        process.stdout.write(line + "\n");
       }
     });
+
+    child.stderr?.pipe(process.stderr);
 
     this.#process = handle;
   }

--- a/src/runners/node-process/runner.ts
+++ b/src/runners/node-process/runner.ts
@@ -87,6 +87,9 @@ export class NodeProcessEnvRunner extends BaseEnvRunner {
       this._handleMessage(message);
     });
 
+    child.stdout?.pipe(process.stdout);
+    child.stderr?.pipe(process.stderr);
+
     this.#process = child;
   }
 

--- a/test/fixtures/app.mjs
+++ b/test/fixtures/app.mjs
@@ -9,6 +9,13 @@ export default {
       return Response.json({ body, method: request.method });
     }
 
+    if (url.pathname === "/log") {
+      const marker = url.searchParams.get("marker");
+      console.log(`stdout:${marker}`);
+      console.error(`stderr:${marker}`);
+      return new Response("logged");
+    }
+
     return new Response("ok");
   },
   ipc: {

--- a/test/runners.test.ts
+++ b/test/runners.test.ts
@@ -124,6 +124,49 @@ for (const runnerDef of runners) {
       expect(data.body).toBe("hello");
     });
 
+    it("forwards entry stdout and stderr to the host process", async () => {
+      const marker = `${name}-${randomBytes(4).toString("hex")}`;
+      const stdoutChunks: string[] = [];
+      const stderrChunks: string[] = [];
+      const stdoutWrite = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation((chunk: string | Uint8Array) => {
+          stdoutChunks.push(chunk.toString());
+          return true;
+        });
+      const stderrWrite = vi
+        .spyOn(process.stderr, "write")
+        .mockImplementation((chunk: string | Uint8Array) => {
+          stderrChunks.push(chunk.toString());
+          return true;
+        });
+      // In-process runners (self, miniflare) log through the host console,
+      // which vitest patches — capture that channel too
+      const consoleLog = vi.spyOn(console, "log").mockImplementation((...args) => {
+        stdoutChunks.push(args.join(" "));
+      });
+      const consoleError = vi.spyOn(console, "error").mockImplementation((...args) => {
+        stderrChunks.push(args.join(" "));
+      });
+
+      try {
+        runner = create(opts("test-stdio"));
+        await waitForReady(runner);
+
+        const res = await runner.fetch(`http://localhost/log?marker=${marker}`);
+        expect(res.status).toBe(200);
+        expect(await res.text()).toBe("logged");
+
+        await waitFor(() => stdoutChunks.join("").includes(`stdout:${marker}`), 5000);
+        await waitFor(() => stderrChunks.join("").includes(`stderr:${marker}`), 5000);
+      } finally {
+        stdoutWrite.mockRestore();
+        stderrWrite.mockRestore();
+        consoleLog.mockRestore();
+        consoleError.mockRestore();
+      }
+    });
+
     it("sends and receives messages", async () => {
       runner = create(opts("test-msg"));
       await waitForReady(runner);
@@ -271,67 +314,6 @@ for (const runnerDef of runners) {
     });
   });
 }
-
-describe.skipIf(!hasBun)("BunProcessEnvRunner stdio", () => {
-  let runner: EnvRunner | undefined;
-  let tmpDir: string | undefined;
-
-  afterEach(async () => {
-    await runner?.close();
-    runner = undefined;
-    if (tmpDir) {
-      rmSync(tmpDir, { recursive: true, force: true });
-      tmpDir = undefined;
-    }
-    vi.restoreAllMocks();
-  });
-
-  it("forwards child stdout and stderr to the host process", async () => {
-    tmpDir = mkdtempSync(join(_dir, ".tmp-stdio-"));
-    const entryPath = join(tmpDir, "app.mjs");
-
-    writeFileSync(
-      entryPath,
-      `
-export default {
-  fetch() {
-    console.log("stdout from bun process runner");
-    console.error("stderr from bun process runner");
-    return new Response("ok");
-  },
-};
-`,
-    );
-
-    const stdoutChunks: string[] = [];
-    const stderrChunks: string[] = [];
-    const stdoutWrite = vi
-      .spyOn(process.stdout, "write")
-      .mockImplementation((chunk: string | Uint8Array) => {
-        stdoutChunks.push(chunk.toString());
-        return true;
-      });
-    const stderrWrite = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation((chunk: string | Uint8Array) => {
-        stderrChunks.push(chunk.toString());
-        return true;
-      });
-
-    runner = new BunProcessEnvRunner({ name: "test-stdio", data: { entry: entryPath } });
-    await waitForReady(runner);
-
-    const res = await runner.fetch("http://localhost/");
-    expect(res.status).toBe(200);
-    expect(await res.text()).toBe("ok");
-
-    await waitFor(() => stdoutChunks.join("").includes("stdout from bun process runner"));
-    await waitFor(() => stderrChunks.join("").includes("stderr from bun process runner"));
-
-    stdoutWrite.mockRestore();
-    stderrWrite.mockRestore();
-  });
-});
 
 // --- reloadModule tests ---
 

--- a/test/runners.test.ts
+++ b/test/runners.test.ts
@@ -5,7 +5,7 @@ import { randomBytes } from "node:crypto";
 import { inspect } from "node:util";
 import { fileURLToPath } from "node:url";
 import { resolve, dirname, join } from "node:path";
-import { describe, expect, it, afterEach } from "vitest";
+import { describe, expect, it, afterEach, vi } from "vitest";
 import type { EnvRunner } from "../src/index.ts";
 
 function hasRuntime(cmd: string): boolean {
@@ -271,6 +271,67 @@ for (const runnerDef of runners) {
     });
   });
 }
+
+describe.skipIf(!hasBun)("BunProcessEnvRunner stdio", () => {
+  let runner: EnvRunner | undefined;
+  let tmpDir: string | undefined;
+
+  afterEach(async () => {
+    await runner?.close();
+    runner = undefined;
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("forwards child stdout and stderr to the host process", async () => {
+    tmpDir = mkdtempSync(join(_dir, ".tmp-stdio-"));
+    const entryPath = join(tmpDir, "app.mjs");
+
+    writeFileSync(
+      entryPath,
+      `
+export default {
+  fetch() {
+    console.log("stdout from bun process runner");
+    console.error("stderr from bun process runner");
+    return new Response("ok");
+  },
+};
+`,
+    );
+
+    const stdoutChunks: string[] = [];
+    const stderrChunks: string[] = [];
+    const stdoutWrite = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: string | Uint8Array) => {
+        stdoutChunks.push(chunk.toString());
+        return true;
+      });
+    const stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((chunk: string | Uint8Array) => {
+        stderrChunks.push(chunk.toString());
+        return true;
+      });
+
+    runner = new BunProcessEnvRunner({ name: "test-stdio", data: { entry: entryPath } });
+    await waitForReady(runner);
+
+    const res = await runner.fetch("http://localhost/");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok");
+
+    await waitFor(() => stdoutChunks.join("").includes("stdout from bun process runner"));
+    await waitFor(() => stderrChunks.join("").includes("stderr from bun process runner"));
+
+    stdoutWrite.mockRestore();
+    stderrWrite.mockRestore();
+  });
+});
 
 // --- reloadModule tests ---
 
@@ -542,4 +603,15 @@ function waitForReady(runner: EnvRunner, timeout = 5000): Promise<void> {
       }
     });
   });
+}
+
+async function waitFor(predicate: () => boolean, timeout = 1000): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeout) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("Timed out waiting for condition");
 }


### PR DESCRIPTION
### What changed

Forward the stdout and stderr streams from the Bun child process runner to the host process.

### Why

When `BunProcessEnvRunner` is hosted from Node.js, the Bun child process is spawned with piped stdio, but those streams were not consumed or forwarded. Runtime logs emitted from the child, such as `console.log` and `console.error` inside a request handler, were therefore hidden from the parent dev process.

This shows up in tools such as Nitro dev when using the `bun-process` runner: handlers execute successfully, but their logs never appear.

### Tests

- `pnpm build`
- `pnpm vitest run test/runners.test.ts --testNamePattern 'BunProcessEnvRunner stdio|BunProcessEnvRunner fetches from runner'`\n- `pnpm test` runs lint and typecheck successfully, then fails in Miniflare tests because the local Workers runtime supports compatibility dates up to `2026-05-27` while the test run uses `2026-06-04`.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Worker/subprocess stdout and stderr are now forwarded to the parent process across Bun, Node, and Deno runners so child console output appears in real time.

* **Behavior**
  * Deno runner now separates structured IPC (JSON) from plain stdout so logs aren’t mistaken for messages.

* **Tests**
  * Added tests that verify stdio forwarding and a polling helper to observe log output.

* **Documentation**
  * Updated testing docs to describe stdio-forwarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->