### PR TITLE
fix(miniflare): preserve Request inputs when dispatching fetch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,8 @@ const runner2 = new NodeProcessEnvRunner({
 - `env-runner/runners/netlify/worker` (`./runners/netlify/worker`) — Netlify worker (sets global Netlify context, delegates to node-worker)
 - `env-runner/vite` (`./vite`) — Vite Environment API helpers (`createViteHotChannel`, `createViteTransport`)
 
+Miniflare Request dispatch preserves method, headers, streaming bodies and cancellation, including explicit RequestInit overrides. Regression coverage lives in `test/miniflare-request.test.ts`.
+
 ## Testing
 
 Generic test infrastructure, cross-runner suites (`runners.test.ts`, `manager.test.ts`, `server.test.ts`, `vite.test.ts`), and shared fixtures: [`.agents/TESTS.md`](.agents/TESTS.md). Runner-specific test notes live with each runner doc:

--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ await using runner = new MiniflareEnvRunner({
 });
 
 const response = await runner.fetch("http://localhost/api");
+// Request inputs also preserve methods, headers, streaming bodies and cancellation.
+// An optional RequestInit overrides the corresponding Request properties.
 ```
 
 Passing `miniflare` explicitly is preferred — the version you install is then the version that runs. A specifier works too (`miniflare: "miniflare"`). If you omit it, the runner imports `miniflare` itself and only fails (with an actionable error) when the package isn't installed either. The `miniflareOptions` object is passed directly to the [Miniflare constructor](https://developers.cloudflare.com/workers/testing/miniflare/) — you can configure bindings, KV, D1, Durable Objects, and any other Miniflare option.

--- a/src/runners/miniflare/runner.ts
+++ b/src/runners/miniflare/runner.ts
@@ -251,6 +251,29 @@ export class MiniflareEnvRunner extends BaseEnvRunner {
         : resolved instanceof URL
           ? resolved.href
           : resolved.url;
+    if (typeof resolved !== "string" && !(resolved instanceof URL)) {
+      // Copy public fields: srvx NodeRequest does not share native Request's private state.
+      const request = new Request(
+        new Request(url, {
+          method: resolved.method,
+          headers: resolved.headers,
+          body: resolved.body,
+          redirect: resolved.redirect,
+          signal: resolved.signal,
+          duplex: "half",
+        } as RequestInit),
+        init,
+      );
+      init = {
+        ...init,
+        method: request.method,
+        headers: request.headers,
+        body: request.body,
+        redirect: request.redirect,
+        signal: request.signal,
+        duplex: "half",
+      } as RequestInit;
+    }
     const res = await this.#miniflare.dispatchFetch(url, init);
     // workerd returns a Response from a different realm — convert to a standard Response
     // so that `instanceof Response` checks work in the caller's context.

--- a/src/runners/miniflare/runner.ts
+++ b/src/runners/miniflare/runner.ts
@@ -245,36 +245,17 @@ export class MiniflareEnvRunner extends BaseEnvRunner {
       return new Response("miniflare env runner is unavailable", { status: 503 });
     }
     const resolved = this._resolveFetchInput(input);
-    const url =
-      typeof resolved === "string"
-        ? resolved
-        : resolved instanceof URL
-          ? resolved.href
-          : resolved.url;
-    if (typeof resolved !== "string" && !(resolved instanceof URL)) {
-      // Copy public fields: srvx NodeRequest does not share native Request's private state.
-      const request = new Request(
-        new Request(url, {
-          method: resolved.method,
-          headers: resolved.headers,
-          body: resolved.body,
-          redirect: resolved.redirect,
-          signal: resolved.signal,
-          duplex: "half",
-        } as RequestInit),
-        init,
-      );
-      init = {
-        ...init,
-        method: request.method,
-        headers: request.headers,
-        body: request.body,
-        redirect: request.redirect,
-        signal: request.signal,
-        duplex: "half",
-      } as RequestInit;
-    }
-    const res = await this.#miniflare.dispatchFetch(url, init);
+    // Treat request adapters as RequestInit dictionaries so all public request
+    // properties survive without requiring native Request's private state.
+    const request =
+      typeof resolved === "string" || resolved instanceof URL
+        ? new Request(resolved, init)
+        : new Request(new Request(resolved.url, resolved), {
+            ...init,
+            referrer: init?.referrer ?? resolved.referrer,
+            referrerPolicy: init?.referrerPolicy ?? resolved.referrerPolicy,
+          });
+    const res = await this.#miniflare.dispatchFetch(request.url, request);
     // workerd returns a Response from a different realm — convert to a standard Response
     // so that `instanceof Response` checks work in the caller's context.
     if (res instanceof Response) {

--- a/test/fixtures/app-request.mjs
+++ b/test/fixtures/app-request.mjs
@@ -1,0 +1,10 @@
+export default {
+  async fetch(request) {
+    return Response.json({
+      method: request.method,
+      cookie: request.headers.get("cookie"),
+      authorization: request.headers.get("authorization"),
+      body: await request.text(),
+    });
+  },
+};

--- a/test/miniflare-request.test.ts
+++ b/test/miniflare-request.test.ts
@@ -1,0 +1,100 @@
+import { fileURLToPath } from "node:url";
+import { beforeAll, afterAll, describe, expect, test } from "vitest";
+import * as miniflare from "miniflare";
+import { serve } from "srvx/node";
+import { MiniflareEnvRunner } from "../src/runners/miniflare/runner.ts";
+
+const url = "http://localhost/echo";
+const init = {
+  method: "POST",
+  headers: { cookie: "session=alice", authorization: "Bearer sample" },
+  body: "payload",
+};
+const expected = {
+  method: "POST",
+  cookie: "session=alice",
+  authorization: "Bearer sample",
+  body: "payload",
+};
+
+describe("Miniflare Request inputs", () => {
+  let runner: MiniflareEnvRunner;
+  beforeAll(async () => {
+    runner = new MiniflareEnvRunner({
+      name: "request-input",
+      miniflare,
+      data: { entry: fileURLToPath(new URL("./fixtures/app-request.mjs", import.meta.url)) },
+    });
+    await runner.waitForReady();
+  });
+  afterAll(async () => {
+    await runner?.close();
+  });
+
+  test.each(["string", "URL", "relative", "Request"])("preserves %s input", async (kind) => {
+    const input =
+      kind === "Request"
+        ? new Request(url, init)
+        : kind === "URL"
+          ? new URL(url)
+          : kind === "relative"
+            ? "/echo"
+            : url;
+    expect(await (await runner.fetch(input, kind === "Request" ? undefined : init)).json()).toEqual(
+      expected,
+    );
+  });
+  test("honors explicit overrides and ignores undefined fields", async () => {
+    expect(
+      await (
+        await runner.fetch(new Request(url, init), { method: undefined, headers: undefined })
+      ).json(),
+    ).toEqual(expected);
+    expect(
+      await (
+        await runner.fetch(new Request(url, init), {
+          method: "PUT",
+          headers: { cookie: "override" },
+          body: "replacement",
+        })
+      ).json(),
+    ).toEqual({ method: "PUT", cookie: "override", authorization: null, body: "replacement" });
+  });
+  test("preserves HEAD and isolates concurrent credentials", async () => {
+    expect(await (await runner.fetch(new Request(url, { method: "HEAD" }))).text()).toBe("");
+    const values = await Promise.all(
+      ["alice", "bob"].map(
+        async (cookie) =>
+          (await (await runner.fetch(new Request(url, { headers: { cookie } }))).json()).cookie,
+      ),
+    );
+    expect(values).toEqual(["alice", "bob"]);
+  });
+  test("forwards streaming srvx NodeRequest inputs", async () => {
+    const server = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      silent: true,
+      fetch: (request) => runner.fetch(request),
+    });
+    await server.ready();
+    try {
+      const body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("payload"));
+          controller.close();
+        },
+      });
+      expect(
+        await (await fetch(server.url!, { ...init, body, duplex: "half" } as RequestInit)).json(),
+      ).toEqual(expected);
+    } finally {
+      await server.close(true);
+    }
+  });
+  test("preserves an aborted Request signal", async () => {
+    await expect(
+      runner.fetch(new Request(url, { signal: AbortSignal.abort() })),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+});

--- a/test/miniflare-request.test.ts
+++ b/test/miniflare-request.test.ts
@@ -19,10 +19,23 @@ const expected = {
 
 describe("Miniflare Request inputs", () => {
   let runner: MiniflareEnvRunner;
+  let forwarded: RequestInit | undefined;
   beforeAll(async () => {
     runner = new MiniflareEnvRunner({
       name: "request-input",
-      miniflare,
+      miniflare: {
+        ...miniflare,
+        Miniflare: class extends miniflare.Miniflare {
+          constructor(options: ConstructorParameters<typeof miniflare.Miniflare>[0]) {
+            super(options);
+            const dispatch = this.dispatchFetch;
+            this.dispatchFetch = (input, init) => {
+              forwarded = init as RequestInit;
+              return dispatch(input, init);
+            };
+          }
+        },
+      },
       data: { entry: fileURLToPath(new URL("./fixtures/app-request.mjs", import.meta.url)) },
     });
     await runner.waitForReady();
@@ -44,6 +57,22 @@ describe("Miniflare Request inputs", () => {
       expected,
     );
   });
+  test("preserves a non-default referrer and its override", async () => {
+    const request = new Request(url, {
+      referrer: "http://localhost/source",
+      referrerPolicy: "unsafe-url",
+    });
+    await (await runner.fetch(request)).text();
+    expect(forwarded?.referrer).toBe("http://localhost/source");
+    expect(forwarded?.referrerPolicy).toBe("unsafe-url");
+    const override = new Request(url, {
+      referrer: "http://localhost/source",
+      referrerPolicy: "unsafe-url",
+    });
+    await (await runner.fetch(override, { referrer: "http://localhost/override" })).text();
+    expect(forwarded?.referrer).toBe("http://localhost/override");
+  });
+
   test("honors explicit overrides and ignores undefined fields", async () => {
     expect(
       await (


### PR DESCRIPTION
## Problem and change

`runner.fetch(new Request(url, init))` currently dispatches only the URL to Miniflare. A POST carrying cookies, authorization and a body reaches the worker as an anonymous GET.

Closes [Miniflare Request input loss — unjs/env-runner#46](https://github.com/unjs/env-runner/issues/46).

Normalize request inputs through their complete public RequestInit properties, apply overrides, and pass the URL plus resulting Request as the dispatch initialization dictionary. This preserves referrer/referrerPolicy as well as method, headers, streaming body and signal, while supporting srvx NodeRequest without native private-state assumptions. Passing a native Request directly as Miniflare input is incompatible with its separate undici Request implementation; the URL/init form avoids that brand mismatch. String, URL and relative URL behavior is unchanged; no body buffering or shared per-request state is introduced.

## Sample and use case

```js
await runner.fetch(new Request('http://localhost/api/form', {
  method: 'POST',
  headers: { cookie: 'session=alice', authorization: 'Bearer sample' },
  body: 'payload',
}));
```

This now reaches the worker as the supplied POST. Analog/Nitro passes Request objects into the Cloudflare development runner, so the fix restores cookie authentication and form submission parity with production. The issue contains a standalone reproduction; `test/fixtures/app-request.mjs` supplies an echo worker for this PR's regressions.

## Validation

Node 24.15.0, repository-pinned pnpm 11.25.0:

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm test`: lint, formatting, typecheck and coverage suite passed; **399 tests passed, 12 skipped**.
- New focused suite: 9 passed, including non-default referrer and override preservation at the dispatch boundary. Running the same suite against unmodified upstream source produced 5 failures, demonstrating the regressions.

Coverage includes string/URL/relative/Request inputs, explicit and undefined overrides, HEAD, concurrent credentials, streamed srvx NodeRequest bodies and aborted signals. Build is required before the full typecheck because package self-imports resolve through `dist`.

## Suggested AI follow-up prompt

> Review Request dispatch parity across environment runners using this echo fixture. Preserve native RequestInit override semantics, streamed bodies and cancellation, including supported request adapters. Add a minimal failing test before changing another runner; avoid buffering or storing request state globally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved request forwarding to preserve HTTP methods, headers, streaming bodies, redirects, cancellation signals, and other request details.
  - Ensured explicit request options correctly override properties from the original request.
  - Improved handling of requests from different runtime contexts and concurrent credentialed requests.

- **Documentation**
  - Updated runner documentation with details about request preservation and option overrides.

- **Tests**
  - Added coverage for URL, relative, `Request`, streaming, cancellation, credentials, and `HEAD` requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
